### PR TITLE
fix: createProjection and weeks in resolveFloor

### DIFF
--- a/src/Projector.php
+++ b/src/Projector.php
@@ -113,12 +113,21 @@ class Projector
      */
     protected function createProjection(string $period): void
     {
+        $content =  $this->mergeProjectedContent((new $this->projectionName())->defaultContent(), $period);
+        $projection = Projection::firstWhere([
+           'projection_name' => $this->projectionName,
+            'key' => $this->hasKey() ? $this->key() : null,
+            'period' => $period,
+            'start_date' => app(TimeSeries::class)->resolveFloorDate($this->projectedModel->created_at, $period),
+        ]);
+
+        if(is_null($projection))
         $this->projectedModel->projections()->create([
             'projection_name' => $this->projectionName,
             'key' => $this->hasKey() ? $this->key() : null,
             'period' => $period,
             'start_date' => app(TimeSeries::class)->resolveFloorDate($this->projectedModel->created_at, $period),
-            'content' => $this->mergeProjectedContent((new $this->projectionName())->defaultContent(), $period),
+            'content' => $content,
         ]);
     }
 

--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -42,10 +42,11 @@ class TimeSeries
     {
         [$quantity, $periodType] = Str::of($period)->split('/[\s]+/');
 
-//        $startDate = $date->floorUnit($periodType, $quantity);
-        $startDate = $date->startOf($periodType, $quantity);
+    //    $startDate = $date->floorUnit($periodType, $quantity);
+        $startDate = $date->copy()->startOf($periodType, $quantity);
 
         if (in_array($periodType, ['week', 'weeks'])) {
+            $startDate = $date->copy();
             $startDate->startOfWeek($this->getFirstWorkingDayOfWeek());
         }
 


### PR DESCRIPTION
createProjection метод использует хуки в вызове метода получения значений контента. Если пользователь написал свою реализацию хука и в нем логика затрагивает структуру БД, он может создать точно такую же запись в процессе формирования контента, а после еще и создать снова запись уже самим createProjection. То есть возможны теоретические дубликаты.