### PR TITLE
fix: explicit definition for period quantity

### DIFF
--- a/src/Collections/ProjectionCollection.php
+++ b/src/Collections/ProjectionCollection.php
@@ -206,7 +206,7 @@ class ProjectionCollection extends Collection
         [$periodQuantity, $periodType] = Str::of($period)->split('/[\s]+/');
 
         while ($cursorDate->lessThanOrEqualTo($endDate)):
-            $cursorDate->add($periodQuantity, $periodType);
+            $cursorDate->add((int)$periodQuantity, $periodType);
 
             if ($cursorDate->lessThanOrEqualTo($endDate)) {
                 $allProjectionsDates->push(clone $cursorDate);

--- a/src/Collections/ProjectionCollection.php
+++ b/src/Collections/ProjectionCollection.php
@@ -102,8 +102,8 @@ class ProjectionCollection extends Collection
         [$periodQuantity, $periodType] = Str::of($period)->split('/[\s]+/');
 
         // BUG в библиотеке Carbon? Неправильно округляет недели
-        $startDate = $startDateInitial->copy()->startOf($periodType, $periodQuantity);
-        $endDate = $endDateInitial->copy()->startOf($periodType, $periodQuantity);
+        $startDate = $startDateInitial->copy()->floorUnit($periodType, (int)$periodQuantity);
+        $endDate = $endDateInitial->copy()->floorUnit($periodType, (int)$periodQuantity);
 
 //        $startDate->floorUnit($periodType, $periodQuantity);
 //        $endDate->floorUnit($periodType, $periodQuantity);

--- a/src/Collections/ProjectionCollection.php
+++ b/src/Collections/ProjectionCollection.php
@@ -102,8 +102,8 @@ class ProjectionCollection extends Collection
         [$periodQuantity, $periodType] = Str::of($period)->split('/[\s]+/');
 
         // BUG в библиотеке Carbon? Неправильно округляет недели
-        $startDate = $startDateInitial->copy()->floorUnit($periodType, (int)$periodQuantity);
-        $endDate = $endDateInitial->copy()->floorUnit($periodType, (int)$periodQuantity);
+        $startDate = $startDateInitial->copy()->startOf($periodType, (int)$periodQuantity);
+        $endDate = $endDateInitial->copy()->startOf($periodType, (int)$periodQuantity);
 
 //        $startDate->floorUnit($periodType, $periodQuantity);
 //        $endDate->floorUnit($periodType, $periodQuantity);

--- a/src/Collections/ProjectionCollection.php
+++ b/src/Collections/ProjectionCollection.php
@@ -109,8 +109,8 @@ class ProjectionCollection extends Collection
 //        $endDate->floorUnit($periodType, $periodQuantity);
 
         if (in_array($periodType, ['week', 'weeks'])) {
-            $startDate = $startDateInitial->copy()->startOfWeek(app(TimeSeries::class)->getFirstWorkingDayOfWeek());
-            $endDate = $endDateInitial->copy()->startOfWeek(app(TimeSeries::class)->getFirstWorkingDayOfWeek());
+            $startDate = $startDateInitial->copy()->startOfWeek((int)app(TimeSeries::class)->getFirstWorkingDayOfWeek());
+            $endDate = $endDateInitial->copy()->startOfWeek((int)app(TimeSeries::class)->getFirstWorkingDayOfWeek());
         }
 
         if ($startDate->greaterThanOrEqualTo($endDate)) {

--- a/src/Models/Projection.php
+++ b/src/Models/Projection.php
@@ -172,7 +172,7 @@ class Projection extends Model
      */
     public function getEndDateAttribute(): Carbon
     {
-        return $this->start_date->add($this->period)->subSecond();
+        return $this->start_date->add((int)$this->period)->subSecond();
     }
 
     /**

--- a/src/Models/Projection.php
+++ b/src/Models/Projection.php
@@ -172,7 +172,7 @@ class Projection extends Model
      */
     public function getEndDateAttribute(): Carbon
     {
-        return $this->start_date->add((int)$this->period)->subSecond();
+        return $this->start_date->add($this->period)->subSecond();
     }
 
     /**

--- a/src/Projector.php
+++ b/src/Projector.php
@@ -205,7 +205,7 @@ class Projector
         $startDate = $this->projectedModel->created_at->floorUnit($periodType, $quantity);
 
         if (in_array($periodType, ['week', 'weeks'])) {
-            $startDate->startOfWeek(app(TimeSeries::class)->getFirstWorkingDayOfWeek());
+            $startDate->startOfWeek((int)app(TimeSeries::class)->getFirstWorkingDayOfWeek());
         }
 
         return $startDate;

--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -42,7 +42,7 @@ class TimeSeries
     {
         [$quantity, $periodType] = Str::of($period)->split('/[\s]+/');
 
-        $startDate = $date->copy()->floorUnit($periodType, (float)$quantity);
+        $startDate = $date->copy()->floorUnit($periodType, (int)$quantity);
         // $startDate = $date->copy()->startOf($periodType, $quantity);
 
         if (in_array($periodType, ['week', 'weeks'])) {

--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -42,7 +42,7 @@ class TimeSeries
     {
         [$quantity, $periodType] = Str::of($period)->split('/[\s]+/');
 
-        $startDate = $date->copy()->floorUnit($periodType, (int)$quantity);
+        $startDate = $date->copy()->startOf($periodType, (int)$quantity);
         // $startDate = $date->copy()->startOf($periodType, $quantity);
 
         if (in_array($periodType, ['week', 'weeks'])) {

--- a/src/TimeSeries.php
+++ b/src/TimeSeries.php
@@ -42,12 +42,12 @@ class TimeSeries
     {
         [$quantity, $periodType] = Str::of($period)->split('/[\s]+/');
 
-    //    $startDate = $date->floorUnit($periodType, $quantity);
-        $startDate = $date->copy()->startOf($periodType, $quantity);
+        $startDate = $date->copy()->floorUnit($periodType, (float)$quantity);
+        // $startDate = $date->copy()->startOf($periodType, $quantity);
 
         if (in_array($periodType, ['week', 'weeks'])) {
             $startDate = $date->copy();
-            $startDate->startOfWeek($this->getFirstWorkingDayOfWeek());
+            $startDate->startOfWeek((int)$this->getFirstWorkingDayOfWeek());
         }
 
         return $startDate;


### PR DESCRIPTION
C 11 версии Laravel метод add() Carbon принимает int, а не string